### PR TITLE
Update jquery.fractionslider.js

### DIFF
--- a/jquery.fractionslider.js
+++ b/jquery.fractionslider.js
@@ -58,7 +58,8 @@
 				'resumeCallback' : null,
 				'nextSlideCallback' : null,
 				'prevSlideCallback' : null,
-				'pagerCallback' : null
+				'pagerCallback' : null,
+				'onSlideTransitionCallback' : null
 			}, option);
 
 			return this.each(function() {
@@ -241,7 +242,9 @@
 
 			nextSlide();
 			
-			methodeCallback(options.startNextSlideCallback);
+			methodeCallback(function(){
+				options.startNextSlideCallback();
+			});
 		}
 
 
@@ -496,6 +499,9 @@
 						break;
 				}
 			}
+			methodeCallback(function(){
+				options.onSlideTransitionCallback();
+			});
 		}
 
 		// starts a slide


### PR DESCRIPTION
IE doesn't respect "overflow:hidden" on video elements so they flicker and appear outside of the slider area as they're being animated out.  There is probably a better fix available, but this resolves it if needed when passed in as a fractionslider config parameter value for "onSlideTransitionCallback".

$slider.find('video').fadeOut(0).delay(500).fadeIn(0);
